### PR TITLE
Base do mecanismo dos enigmas + Verificação de acerto e quase acerto

### DIFF
--- a/lib/errors/MethodNotAllowedError.ts
+++ b/lib/errors/MethodNotAllowedError.ts
@@ -1,5 +1,0 @@
-export default class MethodNotAllowedError extends Error {
-    constructor() {
-        super("Método HTTP não permitido")
-    }
-}

--- a/lib/errors/MethodNotAllowedError.ts
+++ b/lib/errors/MethodNotAllowedError.ts
@@ -1,0 +1,5 @@
+export default class MethodNotAllowedError extends Error {
+    constructor() {
+        super("Método HTTP não permitido")
+    }
+}

--- a/lib/errors/ResourceNotFoundError.ts
+++ b/lib/errors/ResourceNotFoundError.ts
@@ -1,0 +1,5 @@
+export default class ResourceNotFoundError extends Error {
+    constructor(message: string) {
+        super(message)
+    }
+}

--- a/pages/api/games/puzzle/answer.ts
+++ b/pages/api/games/puzzle/answer.ts
@@ -1,0 +1,21 @@
+import MethodNotAllowedError from "@lib/errors/MethodNotAllowedError"
+import { StatusCodes } from "http-status-codes"
+import { NextApiRequest, NextApiResponse } from "next"
+import ApiResponse from "src/api/ApiResponse"
+import PuzzleAnswerService, { PuzzleAnswerAttemptResponse } from "src/services/PuzzleAnswerService"
+
+export type PuzzleAnswerRequest = {
+    email: string
+    guess: string
+    puzzlePublicId: string
+}
+
+export default async function PuzzleAnswerController(req: NextApiRequest, res: NextApiResponse): Promise<void> {
+    await ApiResponse.withErrorHandler(res, async () => {
+        if (req.method !== "POST") throw new MethodNotAllowedError()
+
+        const params: PuzzleAnswerRequest = req.body
+        const response: PuzzleAnswerAttemptResponse = await PuzzleAnswerService.attempt(params.email, params.guess, params.puzzlePublicId)
+        ApiResponse.build(res, StatusCodes.OK, response.message, response)
+    })
+}

--- a/pages/api/games/puzzle/answer.ts
+++ b/pages/api/games/puzzle/answer.ts
@@ -1,21 +1,18 @@
-import MethodNotAllowedError from "@lib/errors/MethodNotAllowedError"
 import { StatusCodes } from "http-status-codes"
 import { NextApiRequest, NextApiResponse } from "next"
-import ApiResponse from "src/api/ApiResponse"
+import ApiResponse, { HttpMethod } from "src/api/ApiResponse"
+import User from "src/database/model/User"
 import PuzzleAnswerService, { PuzzleAnswerAttemptResponse } from "src/services/PuzzleAnswerService"
 
 export type PuzzleAnswerRequest = {
-    email: string
     guess: string
     puzzlePublicId: string
 }
 
 export default async function PuzzleAnswerController(req: NextApiRequest, res: NextApiResponse): Promise<void> {
-    await ApiResponse.withErrorHandler(res, async () => {
-        if (req.method !== "POST") throw new MethodNotAllowedError()
-
+    await ApiResponse.withCurrentUserAndErrorHandler(req, res, HttpMethod.POST, async (user: User) => {
         const params: PuzzleAnswerRequest = req.body
-        const response: PuzzleAnswerAttemptResponse = await PuzzleAnswerService.attempt(params.email, params.guess, params.puzzlePublicId)
+        const response: PuzzleAnswerAttemptResponse = await PuzzleAnswerService.attempt(user, params.guess, params.puzzlePublicId)
         ApiResponse.build(res, StatusCodes.OK, response.message, response)
     })
 }

--- a/src/api/ApiResponse.ts
+++ b/src/api/ApiResponse.ts
@@ -1,5 +1,8 @@
+import MethodNotAllowedError from "@lib/errors/MethodNotAllowedError"
+import ResourceNotFoundError from "@lib/errors/ResourceNotFoundError"
 import { StatusCodes } from "http-status-codes"
 import { NextApiResponse } from "next"
+import { getURL } from "next/dist/shared/lib/utils"
 
 export default class ApiResponse {
 
@@ -19,5 +22,24 @@ export default class ApiResponse {
     public static build(res: NextApiResponse, statusCode: number, message: string | Array<string>, data?: any): void {
         res.status(statusCode)
            .json(new ApiResponse(statusCode, message, data))
+    }
+
+    public static async withErrorHandler(res: NextApiResponse, action: Function): Promise<void> {
+        try {
+            await action()
+        } catch (error) {
+            if (error instanceof MethodNotAllowedError) {
+                this.build(res, StatusCodes.METHOD_NOT_ALLOWED, error.message)
+                return
+            }
+
+            if (error instanceof ResourceNotFoundError) {
+                this.build(res, StatusCodes.NOT_FOUND, error.message)
+                return
+            }
+
+            console.error(`${getURL()} >> Erro desconhecido`, error)
+            this.build(res, StatusCodes.INTERNAL_SERVER_ERROR, "Ocorreu um erro desconhecido")
+        }
     }
 }

--- a/src/api/ApiResponse.ts
+++ b/src/api/ApiResponse.ts
@@ -1,7 +1,7 @@
 import ResourceNotFoundError from "@lib/errors/ResourceNotFoundError"
 import { StatusCodes } from "http-status-codes"
 import { NextApiResponse } from "next"
-import { getURL, NextApiRequest } from "next/dist/shared/lib/utils"
+import { NextApiRequest } from "next/dist/shared/lib/utils"
 import User from "src/database/model/User"
 
 export enum HttpMethod {
@@ -51,7 +51,7 @@ export default class ApiResponse {
                 return
             }
 
-            console.error(`${getURL()} >> Erro desconhecido`, error)
+            console.error(`${req.url} >> Erro desconhecido`, error)
             this.build(res, StatusCodes.INTERNAL_SERVER_ERROR, "Ocorreu um erro desconhecido")
         }
     }

--- a/src/database/model/User.ts
+++ b/src/database/model/User.ts
@@ -6,6 +6,10 @@ class User extends ModelImpl<User> {
     
     declare name: string
     declare email: string
+
+    public static async findByEmail(email: string): Promise<User | null> {
+        return await User.findOne({ where: { email: email } })
+    }
 }
 
 User.init({

--- a/src/database/model/User.ts
+++ b/src/database/model/User.ts
@@ -15,7 +15,10 @@ class User extends ModelImpl<User> {
 User.init({
     ...commonAttributes,
     name: { type: DataTypes.STRING, allowNull: false },
-    email: { type: DataTypes.STRING, allowNull: false, unique: true }
-}, {sequelize: dataSource})
+    email: { type: DataTypes.STRING, allowNull: false }
+}, {
+    sequelize: dataSource,
+    indexes: [ { unique: true, fields: ["email"] } ]
+})
 
 export default User

--- a/src/database/model/puzzle/Puzzle.ts
+++ b/src/database/model/puzzle/Puzzle.ts
@@ -1,0 +1,25 @@
+import { DataTypes } from "sequelize"
+import dataSource from "src/database/DataSource"
+import ModelImpl, { commonAttributes } from "../ModelImpl"
+
+class Puzzle extends ModelImpl<Puzzle> {
+    
+    declare almostList: Array<string>
+    declare answer: string
+    declare publicId: string
+    declare rewardCode: string
+
+    public static async findByPublicId(publicId: string): Promise<Puzzle | null> {
+        return await Puzzle.findOne({ where: { publicId: publicId } })
+    }
+}
+
+Puzzle.init({
+    ...commonAttributes,
+    almostList: { type: DataTypes.JSON, allowNull: true },
+    answer: { type: DataTypes.STRING, allowNull: false },
+    publicId: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, allowNull: false, unique: true },
+    rewardCode: { type: DataTypes.STRING, allowNull: false, unique: true }
+}, {sequelize: dataSource})
+
+export default Puzzle

--- a/src/database/model/puzzle/Puzzle.ts
+++ b/src/database/model/puzzle/Puzzle.ts
@@ -18,8 +18,14 @@ Puzzle.init({
     ...commonAttributes,
     almostList: { type: DataTypes.JSON, allowNull: true },
     answer: { type: DataTypes.STRING, allowNull: false },
-    publicId: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, allowNull: false, unique: true },
-    rewardCode: { type: DataTypes.STRING, allowNull: false, unique: true }
-}, {sequelize: dataSource})
+    publicId: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, allowNull: false },
+    rewardCode: { type: DataTypes.STRING, allowNull: false }
+}, {
+    sequelize: dataSource,
+    indexes: [ 
+        { unique: true, fields: ["public_id"] },
+        { unique: true, fields: ["reward_code"] }
+    ]
+})
 
 export default Puzzle

--- a/src/database/model/puzzle/PuzzleAnswer.ts
+++ b/src/database/model/puzzle/PuzzleAnswer.ts
@@ -1,4 +1,4 @@
-import { DataTypes, ForeignKey } from "sequelize"
+import { DataTypes } from "sequelize"
 import dataSource from "src/database/DataSource"
 import ModelImpl, { commonAttributes } from "../ModelImpl"
 import User from "../User"
@@ -13,8 +13,8 @@ class PuzzleAnswer extends ModelImpl<PuzzleAnswer> {
     
     declare attempts: number
     declare status: PuzzleAnswerType
-    declare puzzleId: ForeignKey<number>
-    declare userId: ForeignKey<number>
+    declare puzzleId?: number
+    declare userId?: number
 }
 
 PuzzleAnswer.init({
@@ -23,7 +23,7 @@ PuzzleAnswer.init({
     status: { type: DataTypes.ENUM(...Object.keys(PuzzleAnswerType)) }
 }, {sequelize: dataSource})
 
-PuzzleAnswer.belongsTo(User)
-PuzzleAnswer.belongsTo(Puzzle)
+PuzzleAnswer.belongsTo(Puzzle, { foreignKey: "puzzleId", targetKey: "id" })
+PuzzleAnswer.belongsTo(User, { foreignKey: "userId", targetKey: "id" })
 
 export default PuzzleAnswer

--- a/src/database/model/puzzle/PuzzleAnswer.ts
+++ b/src/database/model/puzzle/PuzzleAnswer.ts
@@ -1,0 +1,29 @@
+import { DataTypes, ForeignKey } from "sequelize"
+import dataSource from "src/database/DataSource"
+import ModelImpl, { commonAttributes } from "../ModelImpl"
+import User from "../User"
+import Puzzle from "./Puzzle"
+
+export enum PuzzleAnswerType {
+    PENDING = "PENDING",
+    DONE = "DONE"
+}
+
+class PuzzleAnswer extends ModelImpl<PuzzleAnswer> {
+    
+    declare attempts: number
+    declare status: PuzzleAnswerType
+    declare puzzleId: ForeignKey<number>
+    declare userId: ForeignKey<number>
+}
+
+PuzzleAnswer.init({
+    ...commonAttributes,
+    attempts: { type: DataTypes.INTEGER.UNSIGNED, allowNull: false, defaultValue: 0 },
+    status: { type: DataTypes.ENUM(...Object.keys(PuzzleAnswerType)) }
+}, {sequelize: dataSource})
+
+PuzzleAnswer.belongsTo(User)
+PuzzleAnswer.belongsTo(Puzzle)
+
+export default PuzzleAnswer

--- a/src/services/PuzzleAnswerService.ts
+++ b/src/services/PuzzleAnswerService.ts
@@ -5,7 +5,8 @@ import User from "src/database/model/User"
 
 export type PuzzleAnswerAttemptResponse = { 
     success: boolean, 
-    message: string 
+    message: string,
+    rewardCode?: string
 }
 
 export default class PuzzleAnswerService {
@@ -15,13 +16,13 @@ export default class PuzzleAnswerService {
         if (!puzzle) throw new ResourceNotFoundError("Enigma não encontrado")
 
         const answeredAlready: boolean = !!(await PuzzleAnswer.findOne({ where: { userId: user.id, puzzleId: puzzle.id, status: PuzzleAnswerType.DONE } }))
-        if (answeredAlready) return { success: true, message: "Enigma já respondido" }
+        if (answeredAlready) return { success: true, message: "Enigma já respondido", rewardCode: puzzle.rewardCode }
 
         const normalizedUserGuess: string = this.normalize(userGuess)
         const guessedCorrectly: boolean = normalizedUserGuess == this.normalize(puzzle.answer)
         if (guessedCorrectly) {
             await this.save(user, puzzle, PuzzleAnswerType.DONE)
-            return { success: true, message: "Acertou, mizerávi" }
+            return { success: true, message: "Acertou, mizerávi", rewardCode: puzzle.rewardCode }
         }
 
         const almostGotItRight: boolean = puzzle.almostList.some((almost: string) => normalizedUserGuess == this.normalize(almost))

--- a/src/services/PuzzleAnswerService.ts
+++ b/src/services/PuzzleAnswerService.ts
@@ -15,9 +15,21 @@ export default class PuzzleAnswerService {
         if (answeredAlready) return { success: true, message: "Enigma já respondido" }
 
         const normalizedUserGuess: string = this.normalize(userGuess)
+        const guessedCorrectly: boolean = normalizedUserGuess == this.normalize(puzzle.answer)
+        if (guessedCorrectly) {
+            await this.save(user, puzzle, PuzzleAnswerType.DONE)
+            return { success: true, message: "Acertou, mizerávi" }
+        }
         return { success: false, message: "Hmmm, não é isso" }
     }
 
+    private static async save(user: User, puzzle: Puzzle, status: PuzzleAnswerType = PuzzleAnswerType.PENDING): Promise<void> {
+        const [puzzleAnswer, created] = await PuzzleAnswer.findOrCreate({ where: { userId: user.id, puzzleId: puzzle.id } })
+
+        puzzleAnswer.status = status
+        puzzleAnswer.attempts++
+        await puzzleAnswer.save()
+    }
 
     private static normalize(value: string): string {
         return value.normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase().trim()

--- a/src/services/PuzzleAnswerService.ts
+++ b/src/services/PuzzleAnswerService.ts
@@ -1,3 +1,6 @@
+import ResourceNotFoundError from "@lib/errors/ResourceNotFoundError"
+import Puzzle from "src/database/model/puzzle/Puzzle"
+import PuzzleAnswer, { PuzzleAnswerType } from "src/database/model/puzzle/PuzzleAnswer"
 import User from "src/database/model/User"
 
 export type PuzzleAnswerAttemptResponse = { 
@@ -20,6 +23,13 @@ export default class PuzzleAnswerService {
             await this.save(user, puzzle, PuzzleAnswerType.DONE)
             return { success: true, message: "Acertou, mizerávi" }
         }
+
+        const almostGotItRight: boolean = puzzle.almostList.some((almost: string) => normalizedUserGuess == this.normalize(almost))
+        if (almostGotItRight) {
+            await this.save(user, puzzle, PuzzleAnswerType.PENDING)
+            return { success: false, message: `"${userGuess}" foi quase` }
+        }
+
         return { success: false, message: "Hmmm, não é isso" }
     }
 

--- a/src/services/PuzzleAnswerService.ts
+++ b/src/services/PuzzleAnswerService.ts
@@ -8,6 +8,12 @@ export type PuzzleAnswerAttemptResponse = {
 export default class PuzzleAnswerService {
 
     public static async attempt(user: User, userGuess: string, puzzlePublicId: string): Promise<PuzzleAnswerAttemptResponse> {
+        const puzzle: Puzzle | null = await Puzzle.findByPublicId(puzzlePublicId)
+        if (!puzzle) throw new ResourceNotFoundError("Enigma não encontrado")
+
+        const answeredAlready: boolean = !!(await PuzzleAnswer.findOne({ where: { userId: user.id, puzzleId: puzzle.id, status: PuzzleAnswerType.DONE } }))
+        if (answeredAlready) return { success: true, message: "Enigma já respondido" }
+
         return { success: false, message: "Hmmm, não é isso" }
     }
 

--- a/src/services/PuzzleAnswerService.ts
+++ b/src/services/PuzzleAnswerService.ts
@@ -1,0 +1,12 @@
+export type PuzzleAnswerAttemptResponse = { 
+    success: boolean, 
+    message: string 
+}
+
+export default class PuzzleAnswerService {
+
+    public static async attempt(userEmail: string, userGuess: string, puzzlePublicId: string): Promise<PuzzleAnswerAttemptResponse> {
+        return { success: false, message: "Hmmm, não é isso" }
+    }
+
+}

--- a/src/services/PuzzleAnswerService.ts
+++ b/src/services/PuzzleAnswerService.ts
@@ -1,3 +1,5 @@
+import User from "src/database/model/User"
+
 export type PuzzleAnswerAttemptResponse = { 
     success: boolean, 
     message: string 
@@ -5,7 +7,7 @@ export type PuzzleAnswerAttemptResponse = {
 
 export default class PuzzleAnswerService {
 
-    public static async attempt(userEmail: string, userGuess: string, puzzlePublicId: string): Promise<PuzzleAnswerAttemptResponse> {
+    public static async attempt(user: User, userGuess: string, puzzlePublicId: string): Promise<PuzzleAnswerAttemptResponse> {
         return { success: false, message: "Hmmm, não é isso" }
     }
 

--- a/src/services/PuzzleAnswerService.ts
+++ b/src/services/PuzzleAnswerService.ts
@@ -14,7 +14,12 @@ export default class PuzzleAnswerService {
         const answeredAlready: boolean = !!(await PuzzleAnswer.findOne({ where: { userId: user.id, puzzleId: puzzle.id, status: PuzzleAnswerType.DONE } }))
         if (answeredAlready) return { success: true, message: "Enigma já respondido" }
 
+        const normalizedUserGuess: string = this.normalize(userGuess)
         return { success: false, message: "Hmmm, não é isso" }
     }
 
+
+    private static normalize(value: string): string {
+        return value.normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase().trim()
+    }
 }


### PR DESCRIPTION
Originado do #60

Este PR cria o endpoint que vai receber as respostas dos enigmas e fazer as verificações necessárias. São elas:
- Usuário existe
- Enigma existe
- Usuário já respondeu o enigma
- Usuário quase acertou, dentro de uma lista salva em formato JSON no banco (`["quase1", "quase2", ...]`)
- Usuário errou (não está na lista de quase)
- Usuário acertou

Cada tentativa aumenta o `attempts` do usuário na tabela `PuzzleAnswer` e, ao acertar, o status muda para `DONE`. Caso contrário, continua como `PENDING` até ele acertar, mas ainda registrando o número de tentativas.

Criei um _decorator_ para padronizar os retornos da API e já buscar o `User` pra gente.

Precisei arrumar um problema com os índices `unique`, pois o Sequelize estava duplicando eles.