### PR TITLE
Evitando erro transacional por conta da sincronia do banco

### DIFF
--- a/pages/api/sync-database.ts
+++ b/pages/api/sync-database.ts
@@ -1,0 +1,8 @@
+import { NextApiRequest, NextApiResponse } from "next"
+import dataSource from "src/database/DataSource"
+
+export default async function SyncDatabaseController(req: NextApiRequest, res: NextApiResponse) {
+    await dataSource.sync({ alter: true })
+
+    res.status(200).json("OK")
+}

--- a/src/database/DataSource.ts
+++ b/src/database/DataSource.ts
@@ -17,6 +17,4 @@ const dataSource: Sequelize = new Sequelize(
   }
 );
 
-dataSource.sync({ alter: true });
-
 export default dataSource;


### PR DESCRIPTION
Essa sincronia tava dando treta em algumas rotinas de salvamento. Tirei ela da conexão do DB.

Agora, pra sincronizar o banco, tem que fazer uma chamada pra `/api/sync-database` (porque o NextJS não tem trigger pra inicialização, saporra).