### PR TITLE
[Enigmas] Registrando data do acerto e quantidade de "quases" + outros ajustes

### DIFF
--- a/src/database/model/puzzle/PuzzleAnswer.ts
+++ b/src/database/model/puzzle/PuzzleAnswer.ts
@@ -10,11 +10,8 @@ export enum PuzzleAnswerStatus {
 }
 
 class PuzzleAnswer extends ModelImpl<PuzzleAnswer> {
-    
-    declare attempts: number
-    declare status: PuzzleAnswerType
-    declare puzzleId?: number
-    declare userId?: number
+    declare attempts: number;
+    declare almosts: number;
     declare status: PuzzleAnswerStatus;
     declare doneAt: Date;
     declare puzzleId?: number;
@@ -25,8 +22,7 @@ PuzzleAnswer.init(
     {
         ...commonAttributes,
         attempts: { type: DataTypes.INTEGER.UNSIGNED, allowNull: false, defaultValue: 0 },
-    status: { type: DataTypes.ENUM(...Object.keys(PuzzleAnswerType)) }
-}, {sequelize: dataSource})
+        almosts: { type: DataTypes.INTEGER.UNSIGNED, allowNull: false, defaultValue: 0 },
         status: { type: DataTypes.ENUM(...Object.keys(PuzzleAnswerStatus)) },
         doneAt: { type: DataTypes.DATE, allowNull: true, defaultValue: null }
     },

--- a/src/database/model/puzzle/PuzzleAnswer.ts
+++ b/src/database/model/puzzle/PuzzleAnswer.ts
@@ -1,12 +1,12 @@
-import { DataTypes } from "sequelize"
-import dataSource from "src/database/DataSource"
-import ModelImpl, { commonAttributes } from "../ModelImpl"
-import User from "../User"
-import Puzzle from "./Puzzle"
+import { DataTypes } from 'sequelize';
+import dataSource from 'src/database/DataSource';
+import ModelImpl, { commonAttributes } from '../ModelImpl';
+import User from '../User';
+import Puzzle from './Puzzle';
 
-export enum PuzzleAnswerType {
-    PENDING = "PENDING",
-    DONE = "DONE"
+export enum PuzzleAnswerStatus {
+    PENDING = 'PENDING',
+    DONE = 'DONE'
 }
 
 class PuzzleAnswer extends ModelImpl<PuzzleAnswer> {
@@ -15,15 +15,25 @@ class PuzzleAnswer extends ModelImpl<PuzzleAnswer> {
     declare status: PuzzleAnswerType
     declare puzzleId?: number
     declare userId?: number
+    declare status: PuzzleAnswerStatus;
+    declare doneAt: Date;
+    declare puzzleId?: number;
+    declare userId?: number;
 }
 
-PuzzleAnswer.init({
-    ...commonAttributes,
-    attempts: { type: DataTypes.INTEGER.UNSIGNED, allowNull: false, defaultValue: 0 },
+PuzzleAnswer.init(
+    {
+        ...commonAttributes,
+        attempts: { type: DataTypes.INTEGER.UNSIGNED, allowNull: false, defaultValue: 0 },
     status: { type: DataTypes.ENUM(...Object.keys(PuzzleAnswerType)) }
 }, {sequelize: dataSource})
+        status: { type: DataTypes.ENUM(...Object.keys(PuzzleAnswerStatus)) },
+        doneAt: { type: DataTypes.DATE, allowNull: true, defaultValue: null }
+    },
+    { sequelize: dataSource }
+);
 
-PuzzleAnswer.belongsTo(Puzzle, { foreignKey: "puzzleId", targetKey: "id" })
-PuzzleAnswer.belongsTo(User, { foreignKey: "userId", targetKey: "id" })
+PuzzleAnswer.belongsTo(Puzzle, { foreignKey: 'puzzleId', targetKey: 'id' });
+PuzzleAnswer.belongsTo(User, { foreignKey: 'userId', targetKey: 'id' });
 
-export default PuzzleAnswer
+export default PuzzleAnswer;

--- a/src/services/PuzzleAnswerService.ts
+++ b/src/services/PuzzleAnswerService.ts
@@ -33,7 +33,7 @@ export default class PuzzleAnswerService {
             const { data } = await CodeCodesService.claimCode(user, puzzle.rewardCode);
             if (!data) throw new Error('Dados do Code-Codes vieram vazios');
 
-            await this.save(user, puzzle, PuzzleAnswerType.DONE);
+            await this.setAsDone(puzzleAnswer);
             return {
                 success: true,
                 message: `Acertou, mizerávi! Você também ganhou ${data.scoreAcquired} pontos no Code-Codes.`
@@ -60,8 +60,9 @@ export default class PuzzleAnswerService {
             where: { userId: user.id, puzzleId: puzzle.id }
         });
 
-        puzzleAnswer.status = status;
-        puzzleAnswer.attempts++;
+    private static async setAsDone(puzzleAnswer: PuzzleAnswer): Promise<void> {
+        puzzleAnswer.status = PuzzleAnswerStatus.DONE;
+        puzzleAnswer.doneAt = new Date();
         await puzzleAnswer.save();
     }
 

--- a/src/services/PuzzleAnswerService.ts
+++ b/src/services/PuzzleAnswerService.ts
@@ -1,6 +1,6 @@
 import ResourceNotFoundError from '@lib/errors/ResourceNotFoundError';
 import Puzzle from 'src/database/model/puzzle/Puzzle';
-import PuzzleAnswer, { PuzzleAnswerType } from 'src/database/model/puzzle/PuzzleAnswer';
+import PuzzleAnswer, { PuzzleAnswerStatus } from 'src/database/model/puzzle/PuzzleAnswer';
 import User from 'src/database/model/User';
 import CodeCodesService from './CodeCodesService';
 
@@ -19,7 +19,7 @@ export default class PuzzleAnswerService {
         if (!puzzle) throw new ResourceNotFoundError('Enigma não encontrado');
 
         const answeredAlready = !!(await PuzzleAnswer.findOne({
-            where: { userId: user.id, puzzleId: puzzle.id, status: PuzzleAnswerType.DONE }
+            where: { userId: user.id, puzzleId: puzzle.id, status: PuzzleAnswerStatus.DONE }
         }));
         if (answeredAlready)
             return {

--- a/src/services/PuzzleAnswerService.ts
+++ b/src/services/PuzzleAnswerService.ts
@@ -47,7 +47,8 @@ export default class PuzzleAnswerService {
             (almost: string) => normalizedUserGuess == this.normalize(almost)
         );
         if (almostGotItRight) {
-            await this.save(user, puzzle, PuzzleAnswerType.PENDING);
+            puzzleAnswer.almosts++;
+            await puzzleAnswer.save();
             return { success: false, message: `"${userGuess}" foi quase` };
         }
 


### PR DESCRIPTION
Agora passaremos a registrar a data e hora em que o usuário acertou a resposta do enigma, algo que será útil no próximo PR com os rankings.

Também passaremos a registrar a quantidade de quase acertos.

Outros ajustes:
- Corrigido o nome da Enum de Status;
- Corrigido o bug em que os casos de erro não registravam `attempts`