### PR TITLE
Formulário para completar o cadastro (celular + nickname)

### DIFF
--- a/components/_ui/PrivateArea/CompleteYourRegistration/CompleteYourRegistration.tsx
+++ b/components/_ui/PrivateArea/CompleteYourRegistration/CompleteYourRegistration.tsx
@@ -1,0 +1,87 @@
+import oneInputFormStyles from '@components/_ui/OneInputForm/OneInputForm.module.scss';
+import privateAreaStyles from '@components/_ui/PrivateArea/PrivateArea.module.scss';
+import { useUserData } from '@lib/hooks/useUserData';
+import { FormEvent, useState } from 'react';
+import toast from 'react-hot-toast';
+import PhoneInput from 'react-phone-input-international';
+import ApiResponse from 'src/api/ApiResponse';
+
+type Props = {
+    onSuccess: (mobilePhone: string, displayName: string, message: string) => void;
+};
+
+export default function CompleteYourRegistration({ onSuccess }: Props) {
+    const [mobilePhone, setMobilePhone] = useState<string>('');
+    const [displayName, setDisplayName] = useState<string>('');
+    const [isLoading, setLoading] = useState<boolean>(false);
+    const { email } = useUserData();
+
+    async function handleSubmit(event: FormEvent) {
+        try {
+            setLoading(true);
+            event.preventDefault();
+
+            const response = await fetch(`/api/login/complete-registration`, {
+                method: "POST",
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ email, mobilePhone, displayName })
+            });
+
+            const json = await response.json();
+            const { success, message }: ApiResponse = json;
+            if (!success) {
+                toast.error(message.join("\n"));
+                return;
+            }
+
+            onSuccess(mobilePhone, displayName, message[0]);
+        } catch (error) {
+            if (error instanceof Error) {
+                toast.error(`Ocorreu um erro desconhecido [${error.message}]`);
+                return;
+            }
+
+            toast.error(`Ocorreu um erro desconhecido [${error}]`);
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    return (
+        <section className={privateAreaStyles.section}>
+            <div className="container">
+                <h3>Complete seu cadastro para continuar</h3>
+
+                <div className={privateAreaStyles.form}>
+                    <form className={oneInputFormStyles.form} onSubmit={event => void handleSubmit(event)}>
+                        <PhoneInput
+                            country='br'
+                            disableDropdown={true}
+                            inputClass={oneInputFormStyles.input}
+                            specialLabel='Não usaremos seu número para enviar anúncios 🤞'
+                            inputProps={{ required: true, autoFocus: true }}
+                            placeholder='Digite seu telefone'
+                            value={mobilePhone}
+                            onChange={phone => setMobilePhone(phone)}
+                        />
+
+                        <input
+                            type="text"
+                            className={oneInputFormStyles.input}
+                            placeholder="Como devemos te chamar?"
+                            value={displayName}
+                            onChange={event => setDisplayName(event.target.value)}
+                            required
+                        />
+
+                        <button type="submit" disabled={mobilePhone.length < 5 || !displayName.length} className={oneInputFormStyles.button}>
+                            {isLoading ? 'Salvando...' : 'Continuar'}
+                        </button>
+                    </form>
+                </div>
+            </div>
+        </section>
+    );
+}

--- a/components/_ui/PrivateArea/CompleteYourRegistration/index.ts
+++ b/components/_ui/PrivateArea/CompleteYourRegistration/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CompleteYourRegistration";

--- a/lib/types/all.ts
+++ b/lib/types/all.ts
@@ -88,6 +88,8 @@ export type ConfUser = {
     email: string;
     firstName: string;
     fullName: string;
+    mobilePhone?: string;
+    displayName?: string;
 };
 
 export type OkPacket = {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
         "react-easy-emoji": "^1.6.1",
         "react-fast-marquee": "^1.6.0",
         "react-hot-toast": "^2.3.0",
+        "react-phone-input-international": "^2.15.6",
         "react-scroll": "^1.8.9",
         "react-simple-code-editor": "^0.13.0",
         "react-toastify": "^9.0.1",

--- a/pages/api/login/complete-registration.ts
+++ b/pages/api/login/complete-registration.ts
@@ -1,0 +1,27 @@
+import ValidationError from '@lib/errors/ValidationError';
+import { StatusCodes } from 'http-status-codes';
+import { NextApiRequest, NextApiResponse } from 'next';
+import ApiResponse, { HttpMethod } from 'src/api/ApiResponse';
+import User from 'src/database/model/User';
+import UserService from 'src/services/UserService';
+
+export default async function CompleteRegistrationController(
+    req: NextApiRequest,
+    res: NextApiResponse
+): Promise<void> {
+    await ApiResponse.withCurrentUserAndErrorHandler(
+        req,
+        res,
+        HttpMethod.POST,
+        async (user: User) => {
+            const mobilePhone: string | null = req.body.mobilePhone || user.mobilePhone;
+            if (!mobilePhone) throw new ValidationError("Obrigatório informar um número de telefone")
+
+            const displayName: string | null = req.body.displayName || user.displayName;
+            if (!displayName) throw new ValidationError("Obrigatório informar um apelido")
+
+            const response = await UserService.completeRegistration(user, mobilePhone, displayName);
+            ApiResponse.build(res, StatusCodes.OK, response.message, response);
+        }
+    );
+}

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -15,4 +15,15 @@ export default class UserService {
             message: `Obrigado e bom evento!`
         };
     }
+
+    public static async completeRegistration(user: User, mobilePhone: string, displayName: string): Promise<UserResponse> {
+        user.mobilePhone = mobilePhone;
+        user.displayName = displayName;
+        await user.save();
+
+        return {
+            success: true,
+            message: `Seus dados foram salvos`
+        };
+    }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2058,6 +2058,11 @@ classnames@2.2.6:
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
+classnames@^2.2.6:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
+  integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
+
 client-only@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
@@ -3946,10 +3951,30 @@ linebreak@^1.1.0:
     base64-js "0.0.8"
     unicode-trie "^2.0.0"
 
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+  integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
+
+lodash.memoize@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+  integrity sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.reduce@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.reduce/-/lodash.reduce-4.6.0.tgz#f1ab6b839299ad48f784abbf476596f03b914d3b"
+  integrity sha512-6raRe2vxCYBhpBu+B+TtNGUzah+hQjVdu3E17wfusjyrXBka2nBS8OH/gjVZ5PvHOhWmIZTYri09Z6n/QfnNMw==
+
+lodash.startswith@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/lodash.startswith/-/lodash.startswith-4.2.1.tgz#c598c4adce188a27e53145731cdc6c0e7177600c"
+  integrity sha512-XClYR1h4/fJ7H+mmCKppbiBmljN/nGs73iq2SjCT9SF4CBPoUHzLvWmH1GtZMhMBZSiRkHXfeA2RY1eIlJ75ww==
 
 lodash.throttle@^4.1.1:
   version "4.1.1"
@@ -4936,6 +4961,18 @@ react-jss@^8.6.1:
     jss-preset-default "^4.3.0"
     prop-types "^15.6.0"
     theming "^1.3.0"
+
+react-phone-input-international@^2.15.6:
+  version "2.15.6"
+  resolved "https://registry.yarnpkg.com/react-phone-input-international/-/react-phone-input-international-2.15.6.tgz#56e3c42e81c290abedc683c5d97c77faacb78b30"
+  integrity sha512-ke3MeTPUglqB4yoSlF6D9/Av2xXHm2UqnMg7Urgi98D4s7i+iMGplWKNalx5K2F55T7cscotMLbVokFAiroV6w==
+  dependencies:
+    classnames "^2.2.6"
+    lodash.debounce "^4.0.8"
+    lodash.memoize "^4.1.2"
+    lodash.reduce "^4.6.0"
+    lodash.startswith "^4.2.1"
+    prop-types "^15.7.2"
 
 react-redux@^7.1.1:
   version "7.2.8"


### PR DESCRIPTION
Para agilizar, simplesmente copiei o `OneInputForm` e reaproveitei o CSS. Num futuro, talvez valha refatorar para termos um componente genérico.

O componente de telefone permite trocar o DDI, bastando apagá-lo como um texto normal. Ao adicionar outro DDI, a máscara é aplicada automaticamente.

![image](https://github.com/codecon-dev/site/assets/20726950/64b7e4fb-c320-4677-b6c2-4a47083ef846)
